### PR TITLE
Replace the default OpenJDK 7 install with Oracle Java 7

### DIFF
--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -20,9 +20,21 @@ sudo apt-get install -y git-core mercurial vim screen wget curl raptor-utils unz
 # Web server
 sudo apt-get install -y apache2
 
-# Java - install openjdk7 first
-sudo apt-get install -y openjdk-7-jdk
-sudo apt-get install -y tomcat7 ant
+# Install Oracle Java 7 which best supports Java Advanced Imaging (JAI),
+# or uncomment line below and comment out other 6 lines to install OpenJDK7 instead
+#sudo apt-get install -y openjdk-7-jdk
+sudo apt-get install python-software-properties -y
+sudo add-apt-repository ppa:webupd8team/java -y
+sudo apt-get update -y
+echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
+echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
+sudo apt-get install oracle-java7-installer -y
+
+# Install Tomcat 7 with JAVA_HOME export so Tomcat starts when install completes,
+# and then patch /etc/default/tomcat7 to specify Oracle Java 7
+export JAVA_HOME=/usr/lib/jvm/java-7-oracle
+sudo -E apt-get install -y tomcat7 ant
+sudo sed -i '/#JAVA_HOME.*$/a JAVA_HOME=/usr/lib/jvm/java-7-oracle/' /etc/default/tomcat7
 
 # MySQL
 echo mysql-server mysql-server/root_password password vivo | sudo debconf-set-selections


### PR DESCRIPTION
VIVO works best with Oracle Java 7 due to a dependency on Java Advanced Imaging (JAI) and possibly others.
