### PR TITLE
Add .env file to ease versions update and config. Fix mysql commands.

### DIFF
--- a/provision/.env
+++ b/provision/.env
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+TIMEZONE="America/New_York"
+
+# http://mirrors.sonic.net/apache/tomcat/tomcat-9/
+TOMCAT_VERSION=9.0.27
+
+# https://github.com/vivo-project/VIVO/branches
+# https://github.com/vivo-project/Vitro/branches
+VIVO_BRANCH="rel-1.11.0-RC"
+
+# http://archive.apache.org/dist/lucene/solr/
+SOLR_VERSION=8.3.0
+
+# http://nyc2.mirrors.digitalocean.com/mariadb/repo
+MARIADB_VERSION=10.4
+
+VIVO_DATABASE="vivo111dev"

--- a/provision/bootstrap.sh
+++ b/provision/bootstrap.sh
@@ -10,6 +10,8 @@ set -e
 # Print shell commands
 set -o verbose
 
+source /home/vagrant/provision/.env
+
 # Update Ubuntu packages. Comment out during development
 apt-get update -y
 
@@ -26,16 +28,16 @@ apt-get install -y maven
 apt-get install -y git vim screen wget curl raptor-utils unzip
 
 # Set time zone
-timedatectl set-timezone America/New_York
+timedatectl set-timezone ${TIMEZONE}
 
 # Install MariaDB
 installMySQL () {
   export DEBIAN_FRONTEND=noninteractive
   apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8
-  add-apt-repository 'deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/10.2/ubuntu xenial main'
+  add-apt-repository "deb [arch=amd64,i386,ppc64el] http://nyc2.mirrors.digitalocean.com/mariadb/repo/${MARIADB_VERSION}/ubuntu xenial main"
   apt-get update -y
   apt-get install -y mariadb-server mariadb-client
-  mysqladmin -u root password vivo
+  mysqladmin --user=root ping
 }
 
 # Install Tomcat 9
@@ -43,10 +45,10 @@ installTomcat () {
   groupadd tomcat || true
   useradd -s /bin/false -g tomcat -d /opt/tomcat tomcat || true
 
-  curl -O http://mirrors.sonic.net/apache/tomcat/tomcat-9/v9.0.22/bin/apache-tomcat-9.0.22.tar.gz
+  curl -o apache-tomcat.tar.gz http://mirrors.sonic.net/apache/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz
 
   mkdir /opt/tomcat || true
-  tar xzvf apache-tomcat-9.0.22.tar.gz -C /opt/tomcat --strip-components=1
+  tar xzvf apache-tomcat.tar.gz -C /opt/tomcat --strip-components=1
 
   chgrp -R tomcat /opt/tomcat
   chmod -R g+r /opt/tomcat/conf

--- a/provision/install.sh
+++ b/provision/install.sh
@@ -10,6 +10,8 @@ set -e
 # Print shell commands
 set -o verbose
 
+source /home/vagrant/provision/.env
+
 # Make data directory
 mkdir -p /opt/vivo
 # Make config directory
@@ -60,8 +62,8 @@ setupTomcat() {
 }
 
 setupMySQL() {
-  mysql --user=root --password=vivo -e "CREATE DATABASE vivo110dev CHARACTER SET utf8;" || true
-  mysql --user=root --password=vivo -e "GRANT ALL ON vivo110dev.* TO 'vivo'@'localhost' IDENTIFIED BY 'vivo';"
+  mysql --user=root -e "CREATE DATABASE ${VIVO_DATABASE} CHARACTER SET utf8;" || true
+  mysql --user=root -e "GRANT ALL ON ${VIVO_DATABASE}.* TO 'vivo'@'localhost' IDENTIFIED BY 'vivo';"
 }
 
 installVIVO() {
@@ -70,15 +72,15 @@ installVIVO() {
   echo 'tomcat           hard    nproc           1500' >> /etc/security/limits.conf
 
   # Vivo
-  BRANCH=rel-1.11.0-RC
   cd /home/vagrant/src
-  git clone https://github.com/vivo-project/Vitro.git Vitro --depth 1 -b ${BRANCH} || true
-  git clone https://github.com/vivo-project/VIVO.git VIVO --depth 1 -b ${BRANCH} || true
+  git clone https://github.com/vivo-project/Vitro.git Vitro --depth 1 -b ${VIVO_BRANCH} || true
+  git clone https://github.com/vivo-project/VIVO.git VIVO --depth 1 -b ${VIVO_BRANCH} || true
 
   cd VIVO
   mvn clean install -DskipTests -s /home/vagrant/provision/vivo/settings.xml
 
   cp /home/vagrant/provision/vivo/runtime.properties /opt/vivo/config/runtime.properties
+  sed -i "s/VIVO_DATABASE/${VIVO_DATABASE}/g" /opt/vivo/config/runtime.properties
   cp /home/vagrant/provision/vivo/developer.properties /opt/vivo/config/developer.properties
   cp /home/vagrant/provision/vivo/build.properties /opt/vivo/config/build.properties
   cp /home/vagrant/provision/vivo/applicationSetup.n3 /opt/vivo/config/applicationSetup.n3

--- a/provision/reset_vivo_db.sh
+++ b/provision/reset_vivo_db.sh
@@ -1,19 +1,20 @@
 #!/bin/bash
 set -e
 
+source /home/vagrant/provision/.env
+
 cd
 
 systemctl stop tomcat
 
-VIVO_DATABASE=vivo110dev
 # save the database schema (without data)
-mysqldump --user=root --password=vivo  --single-transaction --no-data $VIVO_DATABASE > "${VIVO_DATABASE}_schema.sql"
+mysqldump --user=root --single-transaction --no-data $VIVO_DATABASE > "${VIVO_DATABASE}_schema.sql"
 # destroy the database
-mysql --user=root --password=vivo  -e "DROP DATABASE IF EXISTS $VIVO_DATABASE;"
+mysql --user=root  -e "DROP DATABASE IF EXISTS $VIVO_DATABASE;"
 # recreate the database
-mysql --user=root --password=vivo  -e "CREATE DATABASE $VIVO_DATABASE DEFAULT CHARACTER SET utf8;"
-mysql --user=root --password=vivo -e "GRANT ALL ON vivo110dev.* TO 'vivo'@'localhost' IDENTIFIED BY 'vivo';"
-mysql --user=root --password=vivo  $VIVO_DATABASE < "${VIVO_DATABASE}_schema.sql"
+mysql --user=root -e "CREATE DATABASE $VIVO_DATABASE DEFAULT CHARACTER SET utf8;"
+mysql --user=root -e "GRANT ALL ON $VIVO_DATABASE.* TO 'vivo'@'localhost' IDENTIFIED BY 'vivo';"
+mysql --user=root $VIVO_DATABASE < "${VIVO_DATABASE}_schema.sql"
 
 rm -rf /opt/vivo/solr/data
 

--- a/provision/solr.sh
+++ b/provision/solr.sh
@@ -10,16 +10,18 @@ set -e
 # Print shell commands
 set -o verbose
 
-# Install Solr 8.2.0
+source /home/vagrant/provision/.env
+
+# Install Solr
 installSolr () {
 
   echo '*           soft    nofile           65000' >> /etc/security/limits.conf
   echo '*           hard    nproc           65000' >> /etc/security/limits.conf
 
-  curl -O http://archive.apache.org/dist/lucene/solr/8.2.0/solr-8.2.0.tgz
+  curl -o solr.tgz http://archive.apache.org/dist/lucene/solr/${SOLR_VERSION}/solr-${SOLR_VERSION}.tgz
 
   mkdir /opt/solr || true
-  tar xzvf solr-8.2.0.tgz -C /opt/solr --strip-components=1
+  tar xzvf solr.tgz -C /opt/solr --strip-components=1
 
   mkdir -p /opt/solr/server/solr || true
   

--- a/provision/vivo/runtime.properties
+++ b/provision/vivo/runtime.properties
@@ -56,7 +56,7 @@ argon2.time = 1000
 # URL to reflect your database name (if it is not "vitrodb"). Change the username 
 # and password to match the authorized database user you created.
 #
-VitroConnection.DataSource.url = jdbc:mysql://localhost/vivo110dev
+VitroConnection.DataSource.url = jdbc:mysql://localhost/VIVO_DATABASE
 VitroConnection.DataSource.username = vivo
 VitroConnection.DataSource.password = vivo
 


### PR DESCRIPTION
This pull fix #44, fix problems with mysql commands using a wrong password for root and add a way to ease minor update of third party with a `.env` file, avoiding to edit the scripts.

Include Tomcat, Mariadb and Solr updates to last version.